### PR TITLE
Include src folder in NPM distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-/src
 /example
 /dist/example


### PR DESCRIPTION
So that those who are using webpack can import src/vue-chat-scroll.js and use the latest version happily.

This is a quick and dirty fix for #8