### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   ],
   "author": "Theodore Messinezis",
   "license": "MIT",
-  "dependencies": {
-    "vue": "^2.1.10"
+  "peerDependencies": {
+    "vue": "^2.4.4"
   },
   "devDependencies": {
     "babel-preset-es2015-rollup": "^3.0.0",


### PR DESCRIPTION
Update `vue`'s version and change it to a peer dependency. Otherwise if say I'm using Vue 2.4.4 in my project and then require `vue-chat-scroll`, Vue 2.1.10 will be still included so there is duplication.