### PR TITLE
Fix for Issue #30

### DIFF
--- a/dist/vue-chat-scroll.js
+++ b/dist/vue-chat-scroll.js
@@ -33,7 +33,11 @@ var vChatScroll = {
     new MutationObserver(function (e) {
       var config = binding.value || {};
       var pause = config.always === false && scrolled;
-      if (pause || e[e.length - 1].addedNodes.length != 1) return;
+      if(config.scrollonremoved){
+        if (pause || e[e.length - 1].addedNodes.length != 1 && e[e.length - 1].removedNodes.length != 1) return;
+      }else{
+        if (pause || e[e.length - 1].addedNodes.length != 1) return;
+      }         
       scrollToBottom(el, config.smooth);
     }).observe(el, { childList: true, subtree: true });
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-chat-scroll",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-chat-scroll",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Automatic, yet conditional, scroll-to-bottom directive for Vue.js 2.0",
   "main": "dist/vue-chat-scroll.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,17 @@ Alternatively, you can pass a config value to the directive:
 </ul>
 ```
 
+#### Scroll with dissapearing elements in chat window (see [#30](https://github.com/theomessin/vue-chat-scroll/issues/30))
+
+If you have a "loading" animation that disappears when you receive a message from an external source, use the `scrollonremoved` option to ensure the scroll will happen after the element has been removed 
+
+``` html
+<ul class="messages" v-chat-scroll="{always: false, smooth: true, scrollonremoved:true}">
+  <li class="message" v-for="n in messages">{{ n }}</li>
+  <li v-if="loading">loading...</li>
+</ul>
+```
+
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/src/directives/v-chat-scroll.js
+++ b/src/directives/v-chat-scroll.js
@@ -27,7 +27,11 @@ const vChatScroll = {
     (new MutationObserver(e => {
       let config = binding.value || {};
       let pause = config.always === false && scrolled;
-      if (pause || e[e.length - 1].addedNodes.length != 1) return;
+      if(config.scrollonremoved){
+        if (pause || e[e.length - 1].addedNodes.length != 1 && e[e.length - 1].removedNodes.length != 1) return;
+      }else{
+        if (pause || e[e.length - 1].addedNodes.length != 1) return;
+      }
       scrollToBottom(el, config.smooth);
     })).observe(el, { childList: true, subtree: true });
   },


### PR DESCRIPTION
Had the same issue as @christophrumpel where I had loading elements that would be removed when a message was received. Saw the `MutationObserver` detected the removal but not the addition so I've added in a catch for when an element is removed to continue the scroll as it'll pick up the new position of the appended element. Alternatively, scroll should jump back up if there is no new element after the removal.