### PR TITLE
Fixed scrolling with more than one mutation record

### DIFF
--- a/src/directives/v-chat-scroll.js
+++ b/src/directives/v-chat-scroll.js
@@ -28,9 +28,9 @@ const vChatScroll = {
       let config = binding.value || {};
       let pause = config.always === false && scrolled;
       if (config.scrollonremoved) {
-        if (pause || e[e.length - 1].addedNodes.length != 1 && e[e.length - 1].removedNodes.length != 1) return;
+        if (pause || e[0].addedNodes.length != 1 && e[e.length - 1].removedNodes.length != 1) return;
       } else {
-        if (pause || e[e.length - 1].addedNodes.length != 1) return;
+        if (pause || e[0].addedNodes.length != 1) return;
       }
       scrollToBottom(el, config.smooth);
     })).observe(el, { childList: true, subtree: true });


### PR DESCRIPTION
I have a logic, where styles of the message bubbles are formatted like on
facebook - first bubble is rounded everywhere, than next bubble causes
first to change it's corner roundness, etc.
Because of that, there were multiple MutationRecord objects in "e"
object and only the first was the added node. Now your code checks
the last MutationRecord, and it was only the removed node.
I don't know if it will be universal to all cases, but maybe consider
adjustable index of the "e" array?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/theomessin/vue-chat-scroll/45)
<!-- Reviewable:end -->
