### PR TITLE
Fix instant scrolling does not work on initial load

### DIFF
--- a/src/directives/v-chat-scroll.js
+++ b/src/directives/v-chat-scroll.js
@@ -35,7 +35,10 @@ const vChatScroll = {
       scrollToBottom(el, config.smooth);
     })).observe(el, { childList: true, subtree: true });
   },
-  inserted: scrollToBottom
+  inserted: (el, binding) => {
+    const config = binding.value || {};
+    scrollToBottom(el, config.smooth);
+  },
 };
 
 export default vChatScroll;


### PR DESCRIPTION
Fixes #48 

It was smooth on initial load because argument `behavior` was passed and an object is true..