### PR TITLE
Add smoothonremoved option

### DIFF
--- a/dist/vue-chat-scroll.js
+++ b/dist/vue-chat-scroll.js
@@ -33,15 +33,27 @@ var vChatScroll = {
     new MutationObserver(function (e) {
       var config = binding.value || {};
       var pause = config.always === false && scrolled;
+      var addedNodes = e[e.length - 1].addedNodes.length;
+      var removedNodes = e[e.length - 1].removedNodes.length;
+
       if (config.scrollonremoved) {
-        if (pause || e[e.length - 1].addedNodes.length != 1 && e[e.length - 1].removedNodes.length != 1) return;
+        if (pause || addedNodes != 1 && removedNodes != 1) return;
       } else {
-        if (pause || e[e.length - 1].addedNodes.length != 1) return;
+        if (pause || addedNodes != 1) return;
       }
-      scrollToBottom(el, config.smooth);
+
+      var smooth = config.smooth;
+      var loadingRemoved = !addedNodes && removedNodes === 1;
+      if (loadingRemoved && config.scrollonremoved && 'smoothonremoved' in config) {
+        smooth = config.smoothonremoved;
+      }
+      scrollToBottom(el, smooth);
     }).observe(el, { childList: true, subtree: true });
   },
-  inserted: scrollToBottom
+  inserted: function inserted(el, binding) {
+    var config = binding.value || {};
+    scrollToBottom(el, config.smooth);
+  }
 };
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -56,3 +56,12 @@ If you have a "loading" animation that disappears when you receive a message fro
   <li v-if="loading">&bull;&bull;&bull;</li>
 </ul>
 ```
+
+If you want to avoid having smooth scroll in this situation (so it instantly scrolls to bottom after loading), but keep it when new messages come, use the `smoothonremoved` set to `false`, while being able to keep `smooth` set to `true` for later messages.
+``` html
+<ul class="messages" v-chat-scroll="{always: false, smooth: true, scrollonremoved:true, smoothonremoved: false}">
+  <li class="message" v-for="n in messages">{{ n }}</li>
+  <li v-if="loading">&bull;&bull;&bull;</li>
+</ul>
+```
+This option only applies if `scrollonremoved` is set to `true`. When not defined behavior defaults to `smooth` property.

--- a/src/directives/v-chat-scroll.js
+++ b/src/directives/v-chat-scroll.js
@@ -27,12 +27,21 @@ const vChatScroll = {
     (new MutationObserver(e => {
       let config = binding.value || {};
       let pause = config.always === false && scrolled;
+      const addedNodes = e[e.length - 1].addedNodes.length;
+      const removedNodes = e[e.length - 1].removedNodes.length;
+
       if (config.scrollonremoved) {
-        if (pause || e[e.length - 1].addedNodes.length != 1 && e[e.length - 1].removedNodes.length != 1) return;
+        if (pause || addedNodes != 1 && removedNodes != 1) return;
       } else {
-        if (pause || e[e.length - 1].addedNodes.length != 1) return;
+        if (pause || addedNodes != 1) return;
       }
-      scrollToBottom(el, config.smooth);
+
+      let smooth = config.smooth;
+      const loadingRemoved = !addedNodes && removedNodes === 1;
+      if (loadingRemoved && config.scrollonremoved && 'smoothonremoved' in config) {
+        smooth = config.smoothonremoved;
+      }
+      scrollToBottom(el, smooth);
     })).observe(el, { childList: true, subtree: true });
   },
   inserted: (el, binding) => {


### PR DESCRIPTION
Hi @theomessin , first of all many thanks for this package!

I had a situation where I wanted to avoid smooth scrolling after initial load, but wanted to keep it after for new messages. Couldn't get it working with current options, including `scrollonremoved`. If I wanted it to open instantly on bottom on initial load, I had to set `scrollonremoved` with `smooth` as false, which then removed smooth for me for new messages.
In order to tackle this I suggest in this PR adding a new option `smoothonremoved`, which only controls how smooth works on initial load, and only applies if `scrollonremoved` is used. So there should be no change in the way it works for all others using this lib currently.

I'm open for any suggestions, tried to keep naming close to yours, looking forward to feedback 👍 