### PR TITLE
feat: add ability to handle item prepending

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@
  */
 export interface Config {
   enabled: boolean,
+  handlePrepend: boolean,
 };
 
 /**
@@ -10,4 +11,5 @@ export interface Config {
  */
 export const defaultConfig: Config = {
   enabled: true,
+  handlePrepend: false,
 };

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -2,20 +2,31 @@ import { DirectiveOptions } from 'vue';
 import { Config, defaultConfig } from './config';
 import { scroll } from './scroll';
 
-/**
- * We use this state to keep track of all v-chat-scroll mutation observers.
- * When a directive binding is updated for an element, we can fetch the
- * existing MutationObserver, disconnect it, and replace the state
- * with the new MutationObserver (with the new Config callback).
- */
-const state: WeakMap<object, MutationObserver> = new WeakMap();
+const observers: WeakMap<Element, MutationObserver> = new WeakMap();
+const heights: WeakMap<Element, number> = new WeakMap();
 
 /**
  * This function is called when a mutation is observed.
  * The config is used to determine what to do.
  */
-const mutationObserved = (el: Element, config: Config) => {
-  if (config.enabled) scroll(el);
+const mutationObserved = (el: Element, config: Config): void => {
+  // if not enabled, do nothing.
+  if (config.enabled === false) return;
+
+  // if not handling prepend, simply scroll.
+  if (config.handlePrepend === false) {
+    scroll(el);
+    return;
+  }
+
+  // if handling prepend, we need to calculate where to scroll to.
+  // We're prepending if scrollTop is zero and heights has the el.
+  // ScrollTop will be difference in scrollHeight before and after.
+  const scrollTop = (el.scrollTop === 0 && heights.has(el))
+    && (el.scrollHeight - heights.get(el));
+
+  scroll(el, scrollTop);
+  heights.set(el, el.scrollHeight);
 };
 
 /**
@@ -29,17 +40,17 @@ export const directive: DirectiveOptions = {
 
   /**
    * When the directive binding is updated we have to update our MutationObserver.
-   * We disconnect the old MutationObserver (if it exists in our previous state).
-   * We then create (and save) a new MutationObserver with the new configuration.
+   * We disconnect the old MutationObserver (if it already exists in observers).
+   * We then create and save a new MutationObserver with the new callback.
    */
   update: (el, binding) => {
-    if (state.has(el)) state.get(el).disconnect();
+    if (observers.has(el)) observers.get(el).disconnect();
     const config: Config = { ...defaultConfig, ...binding.value };
     const mutationCallback: MutationCallback = () => { mutationObserved(el, config); };
 
     const mutationObserver = new MutationObserver(mutationCallback);
     mutationObserver.observe(el, { childList: true, subtree: true });
-    state.set(el, mutationObserver);
+    observers.set(el, mutationObserver);
   },
 };
 

--- a/src/scroll.ts
+++ b/src/scroll.ts
@@ -1,7 +1,14 @@
 /* istanbul ignore file */
-export const scroll = (el: Element): void => {
-  if (typeof el.scroll === 'function') el.scroll({ top: el.scrollHeight });
-  else el.scrollTop = el.scrollHeight; // eslint-disable-line no-param-reassign
+
+/**
+ * This function will set the scrollTop of an element using either the
+ * scroll method if available, or by changing the scrollTop property.
+ * If no scrollTop is specified, it'll scroll to the bottom.
+ */
+export const scroll = (el: Element, scrollTop?: number): void => {
+  const top = scrollTop || el.scrollHeight - el.clientHeight;
+  if (typeof el.scroll === 'function') el.scroll({ top });
+  else el.scrollTop = top; // eslint-disable-line no-param-reassign
 };
 
 export default scroll;

--- a/tests/directive.spec.ts
+++ b/tests/directive.spec.ts
@@ -76,3 +76,33 @@ test('it obeys the enabled configuration parameter', async () => {
   expect(scroll).toHaveBeenCalledTimes(1);
   expect(scroll).toHaveBeenCalledWith(wrapper.element);
 });
+
+test('it correctly works when prepending', async () => {
+  const Component: Vue.Component = {
+    data: () => ({ handlePrepend: true, items: [1, 2, 3] }),
+    template: '<div v-chat-scroll="{ handlePrepend }"><div v-for="item in items">{{ item }}</div></div>',
+  };
+
+  const localDirective = directive;
+  const localVue = vueTestUtils.createLocalVue();
+  localVue.directive('chat-scroll', localDirective);
+  const wrapper = vueTestUtils.mount(Component, { localVue });
+
+  // Set the current wrapper to be 50 pixels tall.
+  jest.spyOn(wrapper.element, 'scrollHeight', 'get').mockImplementation(() => 50);
+  // We've scrolled all the way to the bottom.
+  jest.spyOn(wrapper.element, 'scrollTop', 'get').mockImplementation(() => 50);
+
+  (wrapper.vm as any).$data.items.pop();
+  await (wrapper.vm as any).$nextTick();
+  expect(scroll).toHaveBeenCalledWith(wrapper.element, false);
+
+  // We've now scrolled all the way to the top.
+  jest.spyOn(wrapper.element, 'scrollTop', 'get').mockImplementation(() => 0);
+  // Now the current wrapper should be 75 pixels tall (25 pixel increase).
+  jest.spyOn(wrapper.element, 'scrollHeight', 'get').mockImplementation(() => 75);
+
+  (wrapper.vm as any).$data.items.unshift(0);
+  await (wrapper.vm as any).$nextTick();
+  expect(scroll).toHaveBeenCalledWith(wrapper.element, 25);
+});


### PR DESCRIPTION
When the handlePrepend config flag is set to true, v-chat-scroll will keep track of the changing scrollHeight of the container. When scrollTop is zero (ie. the user's scrolled all the way to the top) and items are added, v-chat-scroll will scroll to keep the previously viewed item in place by scrolling to the difference in scrollHeight before and after the new items were added.