### PR TITLE
chore: rename dist/index.js to vue-chat-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ new Vue(...);
 If working on a proof of concept or a fiddle, it can be easier to use a script tag. We recommend using a CDN such as unpkg or jsdelvr.
 
 ```html
-<script src="https://unpkg.com/vue-chat-scroll@alpha/dist/index.js"></script>
+<script src="https://unpkg.com/vue-chat-scroll@alpha/dist/vue-chat-scroll.js"></script>
 ```
 
 _vue-chat-scroll_ will attempt to auto-register itself with Vue. This should work as long as `window.Vue` is defined.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   ],
   "license": "MIT",
   "author": "Theodore Messinezis",
-  "main": "dist/index.js",
+  "files": [
+    "dist/vue-chat-scroll.js"
+  ],
+  "main": "dist/vue-chat-scroll.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/theomessin/vue-chat-scroll.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 export default {
   input: 'src/index.ts',
   output: {
-    file: 'dist/index.js',
+    file: 'dist/vue-chat-scroll.js',
     name: 'vue-chat-scroll',
     format: 'umd',
   },


### PR DESCRIPTION
Additionally, only `dist/vue-chat-scroll.js` will be packaged as specified in the package.json `files` array.