### PR TITLE
Added threshold config option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-chat-scroll",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/directives/v-chat-scroll.js
+++ b/src/directives/v-chat-scroll.js
@@ -6,16 +6,16 @@
 */
 
 const scrollToBottom = (el, smooth) => {
-  if (typeof el.scroll === "function") {
-    el.scroll({
-      top: el.scrollHeight,
-      behavior: smooth ? 'smooth' : 'instant'
-    });
-  } else {
-    setTimeout(() => {
-      el.scrollTop = el.scrollHeight;
-    }, 0);
-  }
+  setTimeout(() => {
+    if (typeof el.scroll === "function") {
+      el.scroll({
+        top: el.scrollHeight,
+        behavior: smooth ? 'smooth' : 'instant'
+      });
+    } else {
+        el.scrollTop = el.scrollHeight;
+    }
+  }, 0);
 };
 
 const vChatScroll = {

--- a/src/directives/v-chat-scroll.js
+++ b/src/directives/v-chat-scroll.js
@@ -12,23 +12,34 @@ const scrollToBottom = (el, smooth) => {
       behavior: smooth ? 'smooth' : 'instant'
     });
   } else {
-    el.scrollTop = el.scrollHeight;
+    setTimeout(() => {
+      el.scrollTop = el.scrollHeight;
+    }, 0);
   }
 };
 
 const vChatScroll = {
   bind: (el, binding) => {
     let scrolled = false;
+    let config = binding.value || {};
+    let threshold = config.threshold || 20;
 
     el.addEventListener('scroll', e => {
-      scrolled = el.scrollTop + el.clientHeight + 1 < el.scrollHeight;
+      const hadScrolledBeforeEvent = scrolled;
+      scrolled = el.scrollTop + el.clientHeight + 1 < el.scrollHeight - threshold;
+
       if (scrolled && el.scrollTop === 0) {
         el.dispatchEvent(new Event("v-chat-scroll-top-reached"));
+      }
+
+      if (! hadScrolledBeforeEvent && scrolled) {
+        el.dispatchEvent(new CustomEvent("v-chat-scroll-scrolled-up", { detail: true }));
+      } else if (hadScrolledBeforeEvent && ! scrolled) {
+        el.dispatchEvent(new CustomEvent("v-chat-scroll-scrolled-up", { detail: false }));
       }
     });
 
     (new MutationObserver(e => {
-      let config = binding.value || {};
       if (config.enabled === false) return;
       let pause = config.always === false && scrolled;
       const addedNodes = e[e.length - 1].addedNodes.length;


### PR DESCRIPTION
I added a threshold option to the config. It basically means that you have to scroll up "x" amount of pixels to disable the `scrollToBottom`. I also added a `setTimeout` so the scroll gets sent to the end of the call stack giving the element more render frames.