### PR TITLE
Add option to scroll window element

### DIFF
--- a/dist/vue-chat-scroll.js
+++ b/dist/vue-chat-scroll.js
@@ -10,14 +10,20 @@
   * @author Theodore Messinezis <theo@theomessin.com>
   * @file v-chat-scroll  directive definition
   */
-  var scrollToBottom = function scrollToBottom(el, smooth) {
-    if (typeof el.scroll === "function") {
-      el.scroll({
+  var scrollToBottom = function scrollToBottom(el, smooth, w) {
+    var el2 = el;
+
+    if (w) {
+      el2 = window;
+    }
+
+    if (typeof el2.scroll === "function") {
+      el2.scroll({
         top: el.scrollHeight,
         behavior: smooth ? 'smooth' : 'instant'
       });
     } else {
-      el.scrollTop = el.scrollHeight;
+      el2.scrollTop = el.scrollHeight;
     }
   };
 
@@ -51,7 +57,7 @@
           smooth = config.smoothonremoved;
         }
 
-        scrollToBottom(el, smooth);
+        scrollToBottom(el, smooth, config.window);
       }).observe(el, {
         childList: true,
         subtree: true
@@ -59,7 +65,7 @@
     },
     inserted: function inserted(el, binding) {
       var config = binding.value || {};
-      scrollToBottom(el, config.notSmoothOnInit ? false : config.smooth);
+      scrollToBottom(el, config.notSmoothOnInit ? false : config.smooth, config.window);
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-chat-scroll",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -981,9 +981,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001039",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
-      "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q==",
+      "version": "1.0.30001131",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz",
+      "integrity": "sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw==",
       "dev": true
     },
     "chalk": {

--- a/src/directives/v-chat-scroll.js
+++ b/src/directives/v-chat-scroll.js
@@ -5,14 +5,18 @@
 * @file v-chat-scroll  directive definition
 */
 
-const scrollToBottom = (el, smooth) => {
-  if (typeof el.scroll === "function") {
-    el.scroll({
+const scrollToBottom = (el, smooth, w) => {
+  let el2 = el;
+  if (w) {
+    el2 = window
+  }
+  if (typeof el2.scroll === "function") {
+    el2.scroll({
       top: el.scrollHeight,
       behavior: smooth ? 'smooth' : 'instant'
     });
   } else {
-    el.scrollTop = el.scrollHeight;
+    el2.scrollTop = el.scrollHeight;
   }
 };
 
@@ -45,12 +49,12 @@ const vChatScroll = {
       if (loadingRemoved && config.scrollonremoved && 'smoothonremoved' in config) {
         smooth = config.smoothonremoved;
       }
-      scrollToBottom(el, smooth);
+      scrollToBottom(el, smooth, config.window);
     })).observe(el, { childList: true, subtree: true });
   },
   inserted: (el, binding) => {
     const config = binding.value || {};
-    scrollToBottom(el, config.notSmoothOnInit ? false : config.smooth);
+    scrollToBottom(el, config.notSmoothOnInit ? false : config.smooth, config.window);
   },
 };
 


### PR DESCRIPTION
Currently the directive will only scroll the element that was applied to. That is ok when you are creating a small chat window in a larger app. But if you wish to scroll the whole screen you can't. This enables that option to apply scroll on window element. 

If there interest we might expand this to any other element.